### PR TITLE
Add shields.io badges with some statistics

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,12 @@
 Before `rush` can be considered feature complete, the following features are
 required:
 
+## Repository statistics
+
+![Commits since latest version badge](https://img.shields.io/github/commits-since/lupont/rush/latest?style=flat-square)
+![License badge](https://img.shields.io/github/license/lupont/rush?style=flat-square)
+![Most used language badge](https://img.shields.io/github/languages/top/lupont/rush?style=flat-square)
+
 ### Tab completion
 
 Tab completion that works on files, as well as arguments to programs. It will


### PR DESCRIPTION
Some suggestions for badges. Two of them do not make sense at the moment, but could be nice in the future. Might also be interesting to see number of commits behind main is from dev.