### PR TITLE
Implement the Not trait for ExitStatus

### DIFF
--- a/posh-core/src/engine/mod.rs
+++ b/posh-core/src/engine/mod.rs
@@ -3,6 +3,7 @@ pub mod parser;
 
 use std::fs;
 use std::io::{self, Stdout, Write};
+use std::ops::Not;
 use std::path::PathBuf;
 use std::process::{self, Stdio};
 
@@ -379,5 +380,15 @@ impl From<std::process::ExitStatus> for ExitStatus {
             // FIXME: handle None case
             code: status.code().unwrap(),
         }
+    }
+}
+
+impl Not for ExitStatus {
+    type Output = Self;
+    fn not(self) -> Self::Output {
+        return match self.code {
+            0 => Self::Output { code: 1 },
+            code => Self::Output { code: code },
+        };
     }
 }


### PR DESCRIPTION
This uses the same semantics for ExitStatus as one would use in the shell:

    case $?
      0 -> 1 ;;
      * -> 0 ;;
    esac

And thus allows one to use `! status` in rust to invert the status. For instance when implementing the ! shell operator.

Probably not pretty rust, and maybe even not a good idea to do. Let me know if it doesn't make sense!