### PR TITLE
Allow ! to work on builtins

### DIFF
--- a/posh-core/src/engine/mod.rs
+++ b/posh-core/src/engine/mod.rs
@@ -3,6 +3,7 @@ pub mod parser;
 
 use std::fs;
 use std::io::{self, Stdout, Write};
+use std::ops::Not;
 use std::path::PathBuf;
 use std::process::{self, Stdio};
 
@@ -380,6 +381,16 @@ impl From<std::process::ExitStatus> for ExitStatus {
         Self {
             // FIXME: handle None case
             code: status.code().unwrap(),
+        }
+    }
+}
+
+impl Not for ExitStatus {
+    type Output = Self;
+    fn not(self) -> Self::Output {
+        match self.code {
+            0 => Self::Output { code: 1 },
+            _ => Self::Output { code: 0 },
         }
     }
 }

--- a/test.sh
+++ b/test.sh
@@ -78,6 +78,30 @@ run-tests() {
     expect '/' \
         'foo=a bar=b echo "$foo/$bar"'
 
+    expect 'foo' \
+        ': && echo foo'
+
+    expect '' \
+        ': || echo foo'
+
+    expect '' \
+        ': | : || echo foo'
+
+    expect 'foo' \
+        ': | : && echo foo'
+
+    expect '' \
+        '! : && echo foo'
+
+    expect 'foo' \
+        '! : || echo foo'
+
+    expect 'foo' \
+        '! : | : || echo foo'
+
+    expect '' \
+        '! : | : && echo foo'
+
     # expect $'\n'$'\n' \
     #     'foo=bar echo $foo; echo $foo'
     # expect foo \


### PR DESCRIPTION
Make it possible to invert the exit code from a builtin with !, just like with a regular command.

    ! cd /

($? should be 1, despite moving to /.)

This commit is messy, as I didn't want to break the access to the granular list of exit codes sent all the way to the UI. But my rust is not great, and I don't know what I'm doing. Chances are that you're better of rejecting this pull request and treating it as a bug report instead. But with code that illustrates the behavior I'm looking for. If nothing else, my first real coding session in Rust! :)

This pull request builds upon #8.