### PR TITLE
Make sure deconstructors are run when exiting using ^d

### DIFF
--- a/posh/src/repl/input.rs
+++ b/posh/src/repl/input.rs
@@ -124,14 +124,10 @@ pub fn read_line<W: Write>(engine: &mut Engine<W>) -> Result<String> {
             }
 
             (KeyCode::Char('d'), KeyModifiers::CONTROL) => {
-                if !state.line.is_empty() {
-                    continue;
+                if state.line.is_empty() {
+                    state.about_to_exit = true;
+                    state.line = "exit".to_string();
                 }
-
-                execute!(engine.writer, style::Print("\n\r"))?;
-
-                // FIXME: better control flow than this
-                std::process::exit(0);
             }
 
             (KeyCode::Up, _) | (KeyCode::Char('p'), KeyModifiers::CONTROL) => {


### PR DESCRIPTION
Make a ^d on an empty line mean exit - like currently, but with a softer touch; instead of exiting the process immediately, let it literally emit the symbol "exit" for the repl to deal with. This lets the rust destructors do their thing, including resetting terminal back from raw mode.

This change also makes ^d on a line with text behave as if enter was pressed. This behavior differs between shells - bash behaves the same as with this change. dash has an interesting behavior - it will omit a newline between end of command and command output. Not sure if that's ever useful, but... cool. fish and zsh seem to make ^d on a line with text a no-op, as was the posh behavior prior to this commit. (But why?)

With ^d as enter, you can execute commands with only your left hand (when using qwerty keyboard layouts).

## Note
I think std::process::exit should be avoided even in the implementation of exit, and instead flag it to main/the repl loop somehow, and make them exit - this way, destructors can be used without as much worry. But in this case, we at least trigger the terminal raw mode cleanup.