### PR TITLE
Add spellcheck job and fix spelling errors

### DIFF
--- a/.github/data/project-dictionary.txt
+++ b/.github/data/project-dictionary.txt
@@ -1,0 +1,13 @@
+personal_ws-1.1 en 1000 utf-8
+AST
+CLI
+JSON
+POSIX
+README
+REPL
+Readline
+builtins
+globstar
+pre
+psh
+toolchain

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -50,3 +50,9 @@ jobs:
 
     - name: Run test script
       run: sh test.sh --verbose
+
+  spellcheck:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: gevhaz/word-warden@v1.0.0

--- a/README.md
+++ b/README.md
@@ -35,12 +35,12 @@ The main goals of psh can be summarized in two big tasks:
 - Become (as close as possible) POSIX compliant
   - According to [the
     spec](https://pubs.opengroup.org/onlinepubs/9699919799/utilities/V3_chap02.html)
-  - Without having an explicit init.psh file, no major features that stray
+  - Without having an explicit `init.psh` file, no major features that stray
     from the spec. All off-spec features shall be opt-in via the `set` builtin
     (or possibly another one to stay as on-spec as possible)
 - Include quality of life features
   - Syntax highlighting, abbreviations, automatic suggestions
-  - readline compliance in some form
+  - GNU Readline compliance in some form
   - Tab completion in some form, possibly parsing man pages
   - Off-spec builtins, such as one to get the running time of the latest
     command
@@ -51,4 +51,4 @@ The main goals of psh can be summarized in two big tasks:
 `psh` is written in Rust, and uses `cargo` for building, linting, formatting,
 and testing. Contributing requires having the stable Rust toolchain installed
 (or made available via some sick `podman` aliases or something). The recommended
-way to install this is with [rustup](https://rustup.rs).
+way to install this is with [`rustup`](https://rustup.rs).


### PR DESCRIPTION
Do you have any use for a spellchecker?

You've been doing pretty well without one in the CI this far. I didn't find anything I though were misspellings. Just a couple of commands I would suggest to put as inline code. A command that you run is different from the name of the program, and is more code than natural English, I would say. In the case of GNU Readline, I thought it was appropriate from the context to call it that instead of the command name. I'm going by its Wikipedia to find the True Name of the program.

Let me know if you disapprove of any words being put in the project dictionary or changes in the READMEs, and I'll update the PR.